### PR TITLE
Added support for Common Function Attributes

### DIFF
--- a/src/CGOptions.cpp
+++ b/src/CGOptions.cpp
@@ -199,6 +199,7 @@ DEFINE_GETTER_SETTER_BOOL(fast_execution);
 //GCC C Extensions
 DEFINE_GETTER_SETTER_BOOL(func_attr_inline);
 DEFINE_GETTER_SETTER_BOOL(func_attr_aligned);
+DEFINE_GETTER_SETTER_BOOL(func_attr_flag);
 
 void
 CGOptions::set_default_builtin_kinds()

--- a/src/CGOptions.h
+++ b/src/CGOptions.h
@@ -467,6 +467,8 @@ public:
 	static bool func_attr_aligned(void);
 	static bool func_attr_aligned(bool p);
 
+	static bool func_attr_flag(void);
+	static bool func_attr_flag(bool p);
 private:
 	static bool enabled_builtin_kind(const string &kind);
 
@@ -614,6 +616,7 @@ private:
 	//GCC C Extensions
 	static bool	func_attr_inline_;
 	static bool	func_attr_aligned_;
+	static bool	func_attr_flag_;
 private:
 	CGOptions(void);
 	CGOptions(CGOptions &cgo);

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -71,11 +71,70 @@ using namespace std;
 
 ///////////////////////////////////////////////////////////////////////////////
 
+static vector<FunctionAttribute*> attributes;
 static vector<Function*> FuncList;		// List of all functions in the program
 static vector<FactMgr*>  FMList;        // list of fact managers for each function
 static long cur_func_idx;				// Index into FuncList that we are currently working on
 static bool param_first=true;			// Flag to track output of commas
 static int builtin_functions_cnt;
+static bool attr_emitted = false;
+
+FunctionAttribute::FunctionAttribute(string name, int prob)
+	:  attribute(name), attribute_probability(prob)
+{
+}
+
+void
+FunctionAttribute::OutputAttribute(std::ostream &out, string option)
+{
+	if(!attr_emitted){
+		out << " __attribute__((" << attribute << option;
+		attr_emitted = true;
+	}
+	else
+		out << ", " << attribute << option;
+}
+
+BooleanFunctionAttribute::BooleanFunctionAttribute(string name, int prob)
+	: FunctionAttribute(name, prob)
+{
+}
+
+void
+BooleanFunctionAttribute::OutputAttributes(std::ostream &out)
+{
+	if(rnd_flipcoin(attribute_probability))
+		OutputAttribute(out, "");
+}
+
+MultiValuedFunctionAttribute::MultiValuedFunctionAttribute(string name, int prob, vector<string> arguments)
+	: FunctionAttribute(name, prob), attribute_values(arguments)
+{
+}
+
+void
+MultiValuedFunctionAttribute::OutputAttributes(std::ostream &out)
+{
+	if(rnd_flipcoin(attribute_probability))
+		OutputAttribute(out, "(\"" + attribute_values[rnd_upto(attribute_values.size())] + "\")");
+}
+
+void
+Function::GenerateAttributes()
+{
+	if(CGOptions::func_attr_flag()){
+		vector<string> common_func_attributes = {"artificial", "flatten", "no_reorder", "hot", "cold", "noipa", "used", "unused", \
+							"nothrow", "deprecated", "no_icf", "no_profile_instrument_function", \
+							"no_instrument_function", "no_sanitize_address", "no_sanitize_thread", \
+							"no_sanitize_undefined", "no_split_stack", "noinline", "noplt", "stack_protect"};
+		vector<string>::iterator itr;
+		for(itr = common_func_attributes.begin(); itr < common_func_attributes.end(); itr++)
+			attributes.push_back(new BooleanFunctionAttribute(*itr, FuncAttrProb));
+
+		attributes.push_back(new MultiValuedFunctionAttribute("visibility", FuncAttrProb, {"default", "hidden", "protected", "internal"}));
+		attributes.push_back(new MultiValuedFunctionAttribute("no_sanitize", FuncAttrProb, {"address", "thread", "undefined", "kernel-address", "pointer-compare", "pointer-subtract", "leak"}));
+	}
+}
 
 /*
  * find FactMgr for a function
@@ -497,6 +556,8 @@ Function::make_first(void)
 
 	if(CGOptions::func_attr_aligned() && rnd_flipcoin(FuncAttrAligned))
 		f->func_attr_aligned = true;
+
+	f->GenerateAttributes();
 	return f;
 }
 
@@ -574,6 +635,12 @@ Function::OutputForwardDecl(std::ostream &out)
 		int power = rnd_upto(16);
 		out << " __attribute__((aligned(" << (1 << power) << ")))";
 	}
+	vector<FunctionAttribute*>::iterator itr;
+	for(itr = attributes.begin(); itr < attributes.end(); itr++)
+		(*itr)->OutputAttributes(out);
+	if(attr_emitted)
+		out << "))";
+	attr_emitted = false;
 	out << ";";
 	outputln(out);
 }

--- a/src/Function.h
+++ b/src/Function.h
@@ -59,6 +59,31 @@ class CVQualifiers;
 
 ///////////////////////////////////////////////////////////////////////////////
 
+class FunctionAttribute
+{
+public:
+	string attribute;
+	int attribute_probability;
+	FunctionAttribute(string, int);
+	void OutputAttribute(std::ostream &, string);
+	virtual void OutputAttributes(std::ostream &) = 0;
+};
+
+class BooleanFunctionAttribute : public FunctionAttribute
+{
+public:
+	BooleanFunctionAttribute(string, int);
+	void OutputAttributes(std::ostream &);
+};
+
+class MultiValuedFunctionAttribute : public FunctionAttribute
+{
+public:
+	vector<string> attribute_values;
+	MultiValuedFunctionAttribute(string, int, vector<string>);
+	void OutputAttributes(std::ostream &);
+};
+
 class Function
 {
 public:
@@ -126,6 +151,7 @@ public:
 	//GCC C Extensions
 	bool func_attr_inline;
 	bool func_attr_aligned;
+	void GenerateAttributes();
 
 private:
 	static int deleteFunction(Function* func);

--- a/src/Probabilities.cpp
+++ b/src/Probabilities.cpp
@@ -507,6 +507,9 @@ Probabilities::set_single_name_maps()
 
 	//for choosing function attribute aligned
 	set_single_name("func_attr_aligned", pFuncAttrAligned);
+
+	//for choosing function attributes
+	set_single_name("func_attr_flag", pFuncAttrProb);
 }
 
 void
@@ -550,6 +553,7 @@ Probabilities::initialize_single_probs()
 	//GCC C Extensions
 	m[pFuncAttrInline] = 50;
 	m[pFuncAttrAligned] = 25;
+	m[pFuncAttrProb] = 30;
 
 	if (CGOptions::volatiles())
 		m[pRegularVolatileProb] = 50;

--- a/src/Probabilities.h
+++ b/src/Probabilities.h
@@ -150,6 +150,7 @@ enum ProbName {
 	//for function attributes
 	pFuncAttrInline,
 	pFuncAttrAligned,
+	pFuncAttrProb,
 
 };
 
@@ -232,6 +233,9 @@ enum ProbName {
 
 #define FuncAttrAligned \
 	Probabilities::get_prob(pFuncAttrAligned)
+
+#define FuncAttrProb \
+	Probabilities::get_prob(pFuncAttrProb)
 
 //////////////////////////////////////////////////
 #define UNARY_OPS_PROB_FILTER \

--- a/src/RandomProgramGenerator.cpp
+++ b/src/RandomProgramGenerator.cpp
@@ -212,6 +212,7 @@ static void print_help()
 	cout<< "------------------------------GCC C Extensions------------------------------" << endl << endl;
 	cout << " --func-attr-inline | --no-func-attr-inline: enable | disable generate function attribute inline (disabled by default)." << endl << endl;
 	cout << " --func-attr-aligned | --no-func-attr-aligned: enable | disable generate function attribute aligned (disabled by default)." << endl << endl;
+	cout << " --function-attributes | --no-func-attributes: enable | disable generate common function attributes (disabled by default)." << endl << endl;
 
 }
 
@@ -823,6 +824,15 @@ main(int argc, char **argv)
 			continue;
 		}
 
+		if (strcmp (argv[i], "--function-attributes") == 0) {
+			CGOptions::func_attr_flag(true);
+			continue;
+		}
+
+		if (strcmp (argv[i], "--no-function_attributes") == 0) {
+			CGOptions::func_attr_flag(false);
+			continue;
+		}
 
 		if (strcmp (argv[i], "--max-array-dim") ==0 ) {
 			unsigned long dim;


### PR DESCRIPTION
Added support for following common function attributes - 
1. artificial
2. flatten
3. no_reorder
4. visibility - default/hidden/internal/protected
5. no_instrument_function
6. no_throw
7. no_ipa
8. hot
9. cold
10. deprecated
11. no_icf
12. no_profile_instrument_function
13. no_sanitize - address/thread/undefined
14. no_sanitize_address
15. no_sanitize_undefined
16. no_sanitize_thread
17. no_split_stack
18. noinline
19. noplt
20. stack_protect
21. used
22. unused